### PR TITLE
fix: send fee format based on native asset

### DIFF
--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -30,7 +30,7 @@ function getTxFee(units: FeeUnits, _asset: Asset, _feePrice: number) {
   const feeUnits = chainId === 'terra' ? units['LUNA'] : units[asset]; // Terra ERC20 assets use gas equal to Terra Native assets
   const fee = new BN(feeUnits).times(feePriceInUnit(_asset, _feePrice));
 
-  return unitToCurrency(cryptoassets[getNativeAsset(asset)], fee);
+  return unitToCurrency(cryptoassets[getNativeAsset(_asset)], fee);
 }
 
 function getFeeLabel(fee: string) {

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -1,7 +1,7 @@
-import { chains, unitToCurrency } from '@liquality/cryptoassets';
+import { unitToCurrency } from '@liquality/cryptoassets';
 import BN from 'bignumber.js';
 import { Asset } from '../store/types';
-import { isERC20, isEthereumChain } from './asset';
+import { getNativeAsset, isERC20, isEthereumChain } from './asset';
 import cryptoassets from './cryptoassets';
 
 type FeeUnits = { [asset: Asset]: number };
@@ -20,17 +20,17 @@ const feePriceInUnit = (asset: Asset, feePrice: number) => {
 function getSendFee(asset: Asset, feePrice: number) {
   const assetInfo = cryptoassets[asset];
   const fee = new BN(assetInfo.sendGasLimit).times(feePriceInUnit(asset, feePrice));
-  return unitToCurrency(assetInfo, fee);
+
+  return unitToCurrency(cryptoassets[getNativeAsset(asset)], fee);
 }
 
 function getTxFee(units: FeeUnits, _asset: Asset, _feePrice: number) {
   const chainId = cryptoassets[_asset].chain;
-  const nativeAsset = chains[chainId].nativeAsset;
   const asset = isERC20(_asset) ? 'ERC20' : _asset;
   const feeUnits = chainId === 'terra' ? units['LUNA'] : units[asset]; // Terra ERC20 assets use gas equal to Terra Native assets
   const fee = new BN(feeUnits).times(feePriceInUnit(_asset, _feePrice));
 
-  return unitToCurrency(cryptoassets[nativeAsset], fee);
+  return unitToCurrency(cryptoassets[getNativeAsset(asset)], fee);
 }
 
 function getFeeLabel(fee: string) {


### PR DESCRIPTION
Fixing `getSendFee` method to correctly return fee.