### PR TITLE
feat: pass minimum and maximum amounts in quote

### DIFF
--- a/src/swaps/liquality/LiqualitySwapProvider.ts
+++ b/src/swaps/liquality/LiqualitySwapProvider.ts
@@ -105,12 +105,7 @@ export class LiqualitySwapProvider extends SwapProvider {
     const marketData = this.getMarketData(network);
     // Quotes are retrieved using market data because direct quotes take a long time for BTC swaps (agent takes long to generate new address)
     const market = marketData.find(
-      (market) =>
-        market.provider === this.config.providerId &&
-        market.to === to &&
-        market.from === from &&
-        new BN(amount).gte(new BN(market.min)) &&
-        new BN(amount).lte(new BN(market.max))
+      (market) => market.provider === this.config.providerId && market.to === to && market.from === from
     );
 
     if (!market) return null;
@@ -123,6 +118,8 @@ export class LiqualitySwapProvider extends SwapProvider {
       to,
       fromAmount: fromAmount.toFixed(),
       toAmount: toAmount.toFixed(),
+      min: new BN(market.min),
+      max: new BN(market.max),
     };
   }
 

--- a/src/swaps/liqualityboost/liqualityBoostERC20toNative/LiqualityBoostERC20toNative.ts
+++ b/src/swaps/liqualityboost/liqualityBoostERC20toNative/LiqualityBoostERC20toNative.ts
@@ -106,6 +106,8 @@ class LiqualityBoostERC20toNative extends SwapProvider {
       to,
       fromAmount: quote.fromAmount,
       toAmount: finalQuote.toAmount,
+      minInBridgeAsset: finalQuote.min,
+      maxInBridgeAsset: finalQuote.max,
       bridgeAsset,
       bridgeAssetAmount: quote.toAmount,
       path: quote.path,

--- a/src/swaps/liqualityboost/liqualityBoostERC20toNative/LiqualityBoostERC20toNative.ts
+++ b/src/swaps/liqualityboost/liqualityBoostERC20toNative/LiqualityBoostERC20toNative.ts
@@ -101,12 +101,16 @@ class LiqualityBoostERC20toNative extends SwapProvider {
     });
     if (!finalQuote) return null;
 
+    // increase minimum amount with 5% to minimize calculation
+    // error and price fluctuation
+    const min = finalQuote.min.times(1.05);
+
     return {
       from,
       to,
       fromAmount: quote.fromAmount,
       toAmount: finalQuote.toAmount,
-      minInBridgeAsset: finalQuote.min,
+      minInBridgeAsset: min,
       maxInBridgeAsset: finalQuote.max,
       bridgeAsset,
       bridgeAssetAmount: quote.toAmount,

--- a/src/swaps/liqualityboost/liqualityBoostNativeToERC20/LiqualityBoostNativeToERC20.ts
+++ b/src/swaps/liqualityboost/liqualityBoostNativeToERC20/LiqualityBoostNativeToERC20.ts
@@ -112,6 +112,8 @@ class LiqualityBoostNativeToERC20 extends SwapProvider {
       to,
       fromAmount: quote.fromAmount,
       toAmount: finalQuote.toAmount,
+      min: quote.min,
+      max: quote.max,
       bridgeAsset,
       bridgeAssetAmount: quote.toAmount,
       path: finalQuote.path,


### PR DESCRIPTION
[LIQ-1393](https://linear.app/liquality/issue/LIQ-1393/liquality-boost-or-reduce-the-min-for-pweth-to-btc-so-that-user-can)
[LIQ-1062](https://linear.app/liquality/issue/LIQ-1062/user-need-to-increase-the-input-amount-to-see-the-liquidity-between)