### PR TITLE
fix: overwrite errors on state transitions in swaps

### DIFF
--- a/src/store/actions/performNextAction/index.ts
+++ b/src/store/actions/performNextAction/index.ts
@@ -44,6 +44,11 @@ export const performNextAction = async (
     updates = { error: e.toString() };
   }
   if (updates) {
+    if (!updates.error) {
+      // if no error accured overwrite previous errors in history
+      updates.error = null;
+    }
+
     commit.UPDATE_HISTORY({
       network,
       walletId,
@@ -55,6 +60,7 @@ export const performNextAction = async (
       ...item,
       ...updates,
     } as HistoryItem);
+
     if (!updates.error) {
       dispatch.performNextAction({ network, walletId, id });
     }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,4 +1,4 @@
-import { FeeDetails, NFTAsset, Transaction } from '@chainify/types';
+import { FeeDetails, NFTAsset, Nullable, Transaction } from '@chainify/types';
 import { ChainId } from '@liquality/cryptoassets';
 
 export type NetworkWalletIdMap<T> = Partial<Record<Network, Record<WalletId, T>>>;
@@ -120,7 +120,7 @@ export interface BaseHistoryItem {
   to: Asset;
   type: TransactionType;
   walletId: WalletId;
-  error?: string;
+  error?: Nullable<string>;
   waitingForLock?: boolean;
 }
 


### PR DESCRIPTION
[LIQ-1278](https://linear.app/liquality/issue/LIQ-1278/swap-is-success-but-display-66-stage-in-red-instead-of-success)
[LIQ-1432](https://linear.app/liquality/issue/LIQ-1432/rsk20-to-avax-swap-fail-with-the-mentioned-error-and-even-after)