### PR TITLE
fix: correctly set the dollar value sign

### DIFF
--- a/src/utils/coinFormatter.ts
+++ b/src/utils/coinFormatter.ts
@@ -52,5 +52,6 @@ export const formatFiat = (amount: BN) => {
 };
 
 export const formatFiatUI = (amount: number) => {
-  return isNaN(amount) ? amount : '$' + amount;
+  const _amount = String(amount).replace(/,/g, '');
+  return isNaN(Number(_amount)) ? amount : '$' + amount;
 };


### PR DESCRIPTION
[LIQ-937](https://linear.app/liquality/issue/LIQ-937/dollar-sign-is-missing-on-dashboard-send-screens-in-case-of-value-is)