### PR TITLE
feat: lint no-console rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -27,3 +27,4 @@ rules:
     - error
     - argsIgnorePattern: '_'
       varsIgnorePattern: '_'
+  'no-console': ["warn", { allow: ["warn", "error", "debug"] }]

--- a/packages/wallet-core/src/store/migrations/19_remove_existing_ledger_accounts_test.ts
+++ b/packages/wallet-core/src/store/migrations/19_remove_existing_ledger_accounts_test.ts
@@ -1,5 +1,4 @@
 import { removeExistingLedgerAccounts } from './19_remove_existing_ledger_accounts';
 import state from './19_remove_existing_ledger_accounts.state.pre.json';
 
-const newState = removeExistingLedgerAccounts.migrate(state);
-console.log('newState', newState);
+const _newState = removeExistingLedgerAccounts.migrate(state);

--- a/packages/wallet-core/src/store/migrations/19_remove_existing_ledger_accounts_test.ts
+++ b/packages/wallet-core/src/store/migrations/19_remove_existing_ledger_accounts_test.ts
@@ -1,4 +1,4 @@
 import { removeExistingLedgerAccounts } from './19_remove_existing_ledger_accounts';
 import state from './19_remove_existing_ledger_accounts.state.pre.json';
 
-const _newState = removeExistingLedgerAccounts.migrate(state);
+removeExistingLedgerAccounts.migrate(state);

--- a/packages/wallet-core/src/swaps/fastbtc/FastBTCDepositSwapProvider.ts
+++ b/packages/wallet-core/src/swaps/fastbtc/FastBTCDepositSwapProvider.ts
@@ -81,7 +81,7 @@ class FastBTCDepositSwapProvider extends SwapProvider {
       });
 
       this.socketConnection.on('disconnect', function () {
-        console.log('FastBtc socket disconnected');
+        console.warn('FastBtc socket disconnected');
       });
     });
   }
@@ -268,7 +268,7 @@ class FastBTCDepositSwapProvider extends SwapProvider {
         };
       }
     } catch (e) {
-      console.log(e);
+      console.warn(e);
     }
   }
 

--- a/packages/wallet-core/src/swaps/fastbtc/FastBTCWithdrawSwapProvider.ts
+++ b/packages/wallet-core/src/swaps/fastbtc/FastBTCWithdrawSwapProvider.ts
@@ -262,7 +262,7 @@ class FastBTCWithdrawSwapProvider extends SwapProvider {
         }
       }
     } catch (e) {
-      console.log(e);
+      console.warn(e);
     }
   }
 

--- a/packages/wallet-core/src/utils/quotes.test.ts
+++ b/packages/wallet-core/src/utils/quotes.test.ts
@@ -80,7 +80,6 @@ describe('quotes utils tests', () => {
 
     // sort quotes
     let result = sortQuotes(quotes, Network.Testnet);
-    console.log(result);
     expect(result).toBeDefined();
     expect(result).not.toBeNaN();
 

--- a/packages/wallet-core/src/walletOptions/defaultOptions.ts
+++ b/packages/wallet-core/src/walletOptions/defaultOptions.ts
@@ -20,7 +20,7 @@ const defaultWalletOptions: WalletOptions = {
     },
   },
   createNotification({ message }) {
-    console.log(`Notification: ${message}`);
+    console.warn(`Notification: ${message}`);
   },
 };
 


### PR DESCRIPTION
This PR introduces `no-console` rule to linter : `'no-console': ["warn", { allow: ["warn", "error", "debug"] }]`.
Also it removes all existing `console.log`s from code.