### PR TITLE
fix: add more oneinch parsers

### DIFF
--- a/packages/error-parser/package.json
+++ b/packages/error-parser/package.json
@@ -14,7 +14,8 @@
     "randombytes": "^2.1.0"
   },
   "devDependencies": {
-    "@types/randombytes": "^2.0.0"
+    "@types/randombytes": "^2.0.0",
+    "randexp": "^0.5.3"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/error-parser/src/LiqualityErrors/InsufficientFundsError.ts
+++ b/packages/error-parser/src/LiqualityErrors/InsufficientFundsError.ts
@@ -1,5 +1,4 @@
 import { LiqualityError } from '.';
-import { ErrorType } from '../types/types';
 
 class InsufficientFundsError extends LiqualityError {
   constructor(context?: InsufficientFundsErrorContext, lang?: string) {
@@ -22,7 +21,7 @@ class InsufficientFundsError extends LiqualityError {
   }
 }
 
-InsufficientFundsError.prototype.name = ErrorType.InsufficientFundsError;
+InsufficientFundsError.prototype.name = 'InsufficientFundsError';
 
 export type InsufficientFundsErrorContext = { availAmt: string; neededAmt: string; currency: string };
 export default InsufficientFundsError;

--- a/packages/error-parser/src/LiqualityErrors/InsufficientGasFeeError.ts
+++ b/packages/error-parser/src/LiqualityErrors/InsufficientGasFeeError.ts
@@ -1,6 +1,4 @@
 import { LiqualityError } from '.';
-import { ErrorType } from '../types/types';
-
 class InsufficientGasFeeError extends LiqualityError {
   constructor(context?: InsufficientGasFeeErrorContext, lang?: string) {
     super();
@@ -25,6 +23,6 @@ class InsufficientGasFeeError extends LiqualityError {
   }
 }
 
-InsufficientGasFeeError.prototype.name = ErrorType.InsufficientGasFeeError;
+InsufficientGasFeeError.prototype.name = 'InsufficientGasFeeError';
 export type InsufficientGasFeeErrorContext = { currency: string; gasFee?: string };
 export default InsufficientGasFeeError;

--- a/packages/error-parser/src/LiqualityErrors/InsufficientLiquidityError.ts
+++ b/packages/error-parser/src/LiqualityErrors/InsufficientLiquidityError.ts
@@ -1,6 +1,4 @@
 import { LiqualityError } from '.';
-import { ErrorType } from '../types/types';
-
 class InsufficientLiquidityError extends LiqualityError {
   constructor(context?: InsufficientLiquidityErrorContext, lang?: string) {
     super();
@@ -28,7 +26,7 @@ class InsufficientLiquidityError extends LiqualityError {
   }
 }
 
-InsufficientLiquidityError.prototype.name = ErrorType.InsufficientLiquidityError;
+InsufficientLiquidityError.prototype.name = 'InsufficientLiquidityError';
 
 export type InsufficientLiquidityErrorContext = { from: string; to: string; amount: string };
 export default InsufficientLiquidityError;

--- a/packages/error-parser/src/LiqualityErrors/InternalError.ts
+++ b/packages/error-parser/src/LiqualityErrors/InternalError.ts
@@ -1,6 +1,4 @@
 import { LiqualityError } from '.';
-import { ErrorType } from '../types/types';
-
 class InternalError extends LiqualityError {
   constructor(lang?: string) {
     super();
@@ -19,5 +17,5 @@ class InternalError extends LiqualityError {
   }
 }
 
-InternalError.prototype.name = ErrorType.InternalError;
+InternalError.prototype.name = 'InternalError';
 export default InternalError;

--- a/packages/error-parser/src/LiqualityErrors/ThirdPartyError.ts
+++ b/packages/error-parser/src/LiqualityErrors/ThirdPartyError.ts
@@ -1,6 +1,4 @@
 import { LiqualityError } from '.';
-import { ErrorType } from '../types/types';
-
 class ThirdPartyError extends LiqualityError {
   constructor(context?: ThirdPartyErrorContext, lang?: string) {
     super();
@@ -25,7 +23,7 @@ class ThirdPartyError extends LiqualityError {
   }
 }
 
-ThirdPartyError.prototype.name = ErrorType.ThirdPartyError;
+ThirdPartyError.prototype.name = 'ThirdPartyError';
 
 export enum UserActivity {
   SWAP = 'SWAP',

--- a/packages/error-parser/src/LiqualityErrors/UnknownError.ts
+++ b/packages/error-parser/src/LiqualityErrors/UnknownError.ts
@@ -1,6 +1,4 @@
 import { LiqualityError } from '.';
-import { ErrorType } from '../types/types';
-
 class UnknownError extends LiqualityError {
   constructor(lang?: string) {
     super();
@@ -19,6 +17,6 @@ class UnknownError extends LiqualityError {
   }
 }
 
-UnknownError.prototype.name = ErrorType.UnknownError;
+UnknownError.prototype.name = 'UnknownError';
 
 export default UnknownError;

--- a/packages/error-parser/src/LiqualityErrors/index.ts
+++ b/packages/error-parser/src/LiqualityErrors/index.ts
@@ -4,7 +4,7 @@ import { ERROR_ID_LENGTH } from '../config';
 import { UserErrorMessage } from '../types/types';
 
 export abstract class LiqualityError extends Error {
-  code: number;
+  source: string;
   userMsg: UserErrorMessage;
   devMsg: { desc: string; data: any };
   rawError: never;

--- a/packages/error-parser/src/config.ts
+++ b/packages/error-parser/src/config.ts
@@ -1,17 +1,8 @@
 import { reportToConsole } from './reporters/console';
 import { reportToDiscord } from './reporters/discord';
 import { reportToEmail } from './reporters/email';
-import { ReportType, ErrorSource } from './types/types';
+import { ReportType } from './types/types';
 import { LiqualityError } from './LiqualityErrors';
-import { OneInchSwapErrorParser } from './parsers';
-
-export const ERROR_CODES: Record<ErrorSource, number> = {
-  [ErrorSource.OneInchSwapAPI]: 1000,
-};
-// We will have a errorSourceToParserClass mapping here ...
-export const PARSERS = {
-  [ErrorSource.OneInchSwapAPI]: OneInchSwapErrorParser,
-};
 
 export const REPORTERS: Record<ReportType, <T extends LiqualityError>(error: T) => void> = {
   [ReportType.Console]: reportToConsole,

--- a/packages/error-parser/src/factory/index.ts
+++ b/packages/error-parser/src/factory/index.ts
@@ -1,26 +1,23 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 // Import parser classes here
-
-import { PARSERS } from '../config';
-import { ErrorSource } from '../types/types';
 
 const parserCache = {} as any;
 
 // export function for instantiating parser classes.
 // Parser should be cached upon instantiation
-export function createParser(errorSource: ErrorSource) {
-  const parser = new PARSERS[errorSource]();
-  parserCache[errorSource] = parser;
-
+function createParser<T extends new () => any>(errorParserType: T): InstanceType<T> {
+  const parser = new errorParserType();
+  parserCache[errorParserType.name] = parser;
   return parser;
 }
 
 // export a function for getting a parser
 // The function should check cache first and only instantiate
 // a new parser if non exists in cache.
-export function getParser(errorSource: ErrorSource) {
-  const cachedParser = parserCache[errorSource];
-  if (cachedParser) return cachedParser;
+export function getParser<T extends new () => any>(errorParserType: T): InstanceType<T> {
+  const cachedParser = parserCache[errorParserType.name];
+  if (cachedParser) {
+    return cachedParser;
+  }
 
-  return createParser(errorSource);
+  return createParser(errorParserType);
 }

--- a/packages/error-parser/src/index.ts
+++ b/packages/error-parser/src/index.ts
@@ -1,2 +1,3 @@
 export { setReportConfig } from './reporters';
-export { ErrorSource } from './types/types';
+export { getParser } from './factory';
+export { OneInchSwapErrorParser } from './parsers';

--- a/packages/error-parser/src/index.ts
+++ b/packages/error-parser/src/index.ts
@@ -1,3 +1,3 @@
 export { setReportConfig } from './reporters';
 export { getParser } from './factory';
-export { OneInchSwapErrorParser } from './parsers';
+export { OneInchApproveErrorParser, OneInchQuoteErrorParser, OneInchSwapErrorParser } from './parsers';

--- a/packages/error-parser/src/parsers/ErrorParser.ts
+++ b/packages/error-parser/src/parsers/ErrorParser.ts
@@ -2,6 +2,8 @@
 import { LiqualityError } from '../LiqualityErrors';
 
 export abstract class ErrorParser<SourceError, DataType> {
+  errorSource: string;
+
   protected abstract _parseError(error: SourceError, data: DataType): LiqualityError;
 
   wrap<F extends (...args: Array<any>) => any>(func: F, data: DataType): ReturnType<F> | undefined {

--- a/packages/error-parser/src/parsers/OneInchAPI/ApproveErrorParser.ts
+++ b/packages/error-parser/src/parsers/OneInchAPI/ApproveErrorParser.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { LiqualityError } from '../../LiqualityErrors';
+import { ErrorParser } from '../ErrorParser';
+import ThirdPartyError from '../../LiqualityErrors/ThirdPartyError';
+import InternalError from '../../LiqualityErrors/InternalError';
+import UnknownError from '../../LiqualityErrors/UnknownError';
+import { oneInchInternalErrReason, OneInchError, ONE_INCH_ERRORS } from '.';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export class OneInchApproveErrorParser extends ErrorParser<OneInchError, null> {
+  protected _parseError(error: OneInchError): LiqualityError {
+    let liqError: LiqualityError;
+    let devDesc = '';
+
+    if (error?.name !== 'NodeError') {
+      // All OneInch errors must satisfy this because they are already wrapped in chainify
+      liqError = new UnknownError();
+    } else {
+      const errorDesc = error?.description;
+      switch (true) {
+        case ONE_INCH_ERRORS.INTERNAL_ERROR.test(errorDesc):
+          liqError = new ThirdPartyError();
+          devDesc = oneInchInternalErrReason();
+          break;
+        case ONE_INCH_ERRORS.INVALID_TOKEN_ADDRESS.test(errorDesc):
+          liqError = new InternalError();
+          break;
+        default:
+          liqError = new UnknownError();
+          break;
+      }
+    }
+
+    liqError.source = this.errorSource;
+    liqError.devMsg = { desc: devDesc, data: null };
+    liqError.rawError = error as never;
+
+    return liqError;
+  }
+}
+
+OneInchApproveErrorParser.prototype.errorSource = 'OneInchApproveAPI';

--- a/packages/error-parser/src/parsers/OneInchAPI/QuoteErrorParser.ts
+++ b/packages/error-parser/src/parsers/OneInchAPI/QuoteErrorParser.ts
@@ -1,0 +1,5 @@
+import { OneInchSwapErrorParser } from './SwapErrorParser';
+
+export class OneInchQuoteErrorParser extends OneInchSwapErrorParser {}
+
+OneInchQuoteErrorParser.prototype.errorSource = 'OneInchQuoteAPI';

--- a/packages/error-parser/src/parsers/OneInchAPI/SwapErrorParser.ts
+++ b/packages/error-parser/src/parsers/OneInchAPI/SwapErrorParser.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ERROR_CODES } from '../../config';
 import { LiqualityError } from '../../LiqualityErrors';
 import { ErrorParser } from '../ErrorParser';
 import ThirdPartyError, { UserActivity } from '../../LiqualityErrors/ThirdPartyError';
@@ -8,9 +7,10 @@ import InsufficientGasFeeError from '../../LiqualityErrors/InsufficientGasFeeErr
 import InsufficientLiquidityError from '../../LiqualityErrors/InsufficientLiquidityError';
 import InternalError from '../../LiqualityErrors/InternalError';
 import UnknownError from '../../LiqualityErrors/UnknownError';
+import { oneInchInternalErrReason, OneInchError, ONE_INCH_ERRORS } from '.';
 
-export class OneInchSwapErrorParser extends ErrorParser<OneInchSwapError, OneInchSwapParserDataType> {
-  protected _parseError(error: OneInchSwapError, data: OneInchSwapParserDataType): LiqualityError {
+export class OneInchSwapErrorParser extends ErrorParser<OneInchError, OneInchSwapParserDataType> {
+  protected _parseError(error: OneInchError, data: OneInchSwapParserDataType): LiqualityError {
     let liqError: LiqualityError;
     let devDesc = '';
 
@@ -18,34 +18,42 @@ export class OneInchSwapErrorParser extends ErrorParser<OneInchSwapError, OneInc
       // All OneInch errors must satisfy this because they are already wrapped in chainify
       liqError = new UnknownError();
     } else {
-      switch (error?.description?.toLowerCase()) {
-        case ONE_INCH_SWAP_ERRORS.INSUFFICIENT_LIQUIDITY:
+      const errorDesc = error?.description;
+      switch (true) {
+        case ONE_INCH_ERRORS.INSUFFICIENT_LIQUIDITY.test(errorDesc):
           liqError = new InsufficientLiquidityError({ from: data.from, to: data.to, amount: data.amount });
           break;
-        case ONE_INCH_SWAP_ERRORS.CANNOT_ESTIMATE_1:
+        case ONE_INCH_ERRORS.CANNOT_ESTIMATE_1.test(errorDesc):
           liqError = new ThirdPartyError({ activity: UserActivity.SWAP });
-          devDesc = '1inch could not estimate a quote for the swap';
+          devDesc = 'see https://bit.ly/3Bu3e7U';
           break;
-        case ONE_INCH_SWAP_ERRORS.INSUFFICIENT_GAS_FEE:
+        case ONE_INCH_ERRORS.INSUFFICIENT_GAS_FEE.test(errorDesc):
           liqError = new InsufficientGasFeeError({ currency: data.from });
           break;
-        case ONE_INCH_SWAP_ERRORS.INVALID_TOKEN_ADDRESSES:
+        case ONE_INCH_ERRORS.INVALID_TOKEN_ADDRESS.test(errorDesc):
           liqError = new InternalError();
           break;
-        case ONE_INCH_SWAP_ERRORS.CANNOT_ESTIMATE_WITH_REASON:
-          liqError = new ThirdPartyError({ activity: UserActivity.SWAP });
-          devDesc = '1inch internal error, could be related to slippage for specific tokens';
+        case ONE_INCH_ERRORS.INVALID_TOKEN_PAIR.test(errorDesc):
+          liqError = new InternalError();
           break;
-        case ONE_INCH_SWAP_ERRORS.INSUFFICIENT_FUNDS:
+        case ONE_INCH_ERRORS.CANNOT_ESTIMATE_WITH_REASON.test(errorDesc):
+          liqError = new ThirdPartyError({ activity: UserActivity.SWAP });
+          devDesc = 'see https://bit.ly/3Bu3e7U';
+          break;
+        case ONE_INCH_ERRORS.INSUFFICIENT_FUNDS.test(errorDesc):
           liqError = new InsufficientFundsError({
             currency: data.from,
             availAmt: data.balance,
             neededAmt: data.amount,
           });
           break;
-        case ONE_INCH_SWAP_ERRORS.INSUFFICIENT_ALLOWANCE:
+        case ONE_INCH_ERRORS.INSUFFICIENT_ALLOWANCE.test(errorDesc):
           liqError = new InternalError();
           devDesc = 'Check the approval process for 1inch, approvals are not being made correctly';
+          break;
+        case ONE_INCH_ERRORS.INTERNAL_ERROR.test(errorDesc):
+          liqError = new ThirdPartyError();
+          devDesc = oneInchInternalErrReason();
           break;
         default:
           liqError = new UnknownError();
@@ -53,7 +61,7 @@ export class OneInchSwapErrorParser extends ErrorParser<OneInchSwapError, OneInc
       }
     }
 
-    liqError.code = ERROR_CODES.OneInchSwapAPI;
+    liqError.source = this.errorSource;
     liqError.devMsg = { desc: devDesc, data };
     liqError.rawError = error as never;
 
@@ -61,32 +69,10 @@ export class OneInchSwapErrorParser extends ErrorParser<OneInchSwapError, OneInc
   }
 }
 
-export type OneInchSwapError = {
-  statusCode: number;
-  error: string;
-  description: string;
-  requestId: string;
-  meta: {
-    type: string;
-    value: string;
-  }[];
-  name: string;
-};
-
+OneInchSwapErrorParser.prototype.errorSource = 'OneInchSwapAPI';
 export type OneInchSwapParserDataType = {
   from: string;
   to: string;
   amount: string;
   balance: string;
-};
-
-export const ONE_INCH_SWAP_ERRORS = {
-  INSUFFICIENT_LIQUIDITY: 'Insufficient liquidity'.toLowerCase(),
-  CANNOT_ESTIMATE_1: 'Cannot estimate'.toLowerCase(),
-  CANNOT_ESTIMATE_WITH_REASON:
-    "Cannot estimate. Don't forget about miner fee. Try to leave the buffer of ETH for gas".toLowerCase(),
-  INSUFFICIENT_GAS_FEE: 'You may not have enough ETH balance for gas fee'.toLowerCase(),
-  INVALID_TOKEN_ADDRESSES: 'FromTokenAddress cannot be equals to toTokenAddress'.toLowerCase(),
-  INSUFFICIENT_FUNDS: 'Not enough balance'.toLowerCase(),
-  INSUFFICIENT_ALLOWANCE: 'Not enough allowance'.toLowerCase(),
 };

--- a/packages/error-parser/src/parsers/OneInchAPI/index.ts
+++ b/packages/error-parser/src/parsers/OneInchAPI/index.ts
@@ -1,0 +1,27 @@
+export type OneInchError = {
+  statusCode: number;
+  error: string;
+  description: string;
+  requestId: string;
+  meta: {
+    type: string;
+    value: string;
+  }[];
+  name: string;
+};
+
+export const ONE_INCH_ERRORS = {
+  INSUFFICIENT_LIQUIDITY: /Insufficient liquidity/i,
+  CANNOT_ESTIMATE_1: /Cannot estimate/i,
+  CANNOT_ESTIMATE_WITH_REASON: /Cannot estimate. Don't forget about miner fee. Try to leave the buffer of ETH for gas/i,
+  INSUFFICIENT_GAS_FEE: /You may not have enough ETH balance for gas fee/i,
+  INVALID_TOKEN_PAIR: /FromTokenAddress cannot be equals to toTokenAddress/i,
+  INVALID_TOKEN_ADDRESS: /\S* is wrong address/i,
+  INSUFFICIENT_FUNDS: /Not enough \S* balance/i,
+  INSUFFICIENT_ALLOWANCE: /Not enough \S* allowance/i,
+  INTERNAL_ERROR: /Internal Server Error/i,
+};
+
+export function oneInchInternalErrReason() {
+  return 'This could be due to invalid data, for example providing a string for amount instead of a number';
+}

--- a/packages/error-parser/src/parsers/index.ts
+++ b/packages/error-parser/src/parsers/index.ts
@@ -1,2 +1,4 @@
 export * from './OneInchAPI/SwapErrorParser';
+export * from './OneInchAPI/QuoteErrorParser';
+export * from './OneInchAPI/ApproveErrorParser';
 export * from './ErrorParser';

--- a/packages/error-parser/src/test/index.ts
+++ b/packages/error-parser/src/test/index.ts
@@ -7,3 +7,11 @@ export function getError(func: () => unknown) {
     return error;
   }
 }
+
+export async function getErrorAsync(func: () => Promise<unknown>) {
+  try {
+    return await func();
+  } catch (error) {
+    return error;
+  }
+}

--- a/packages/error-parser/src/test/oneInch/approveAPI.test.ts
+++ b/packages/error-parser/src/test/oneInch/approveAPI.test.ts
@@ -1,0 +1,82 @@
+import { OneInchError, ONE_INCH_ERRORS } from '../../parsers/OneInchAPI';
+import { FAKE_ERROR, getError } from '..';
+import { LiqualityError } from '../../LiqualityErrors';
+import RandExp = require('randexp');
+import { getParser, OneInchApproveErrorParser } from '../..';
+import ThirdPartyError from '../../LiqualityErrors/ThirdPartyError';
+import InternalError from '../../LiqualityErrors/InternalError';
+import UnknownError from '../../LiqualityErrors/UnknownError';
+
+describe('OneInchApproveAPI parser', () => {
+  const parser = getParser(OneInchApproveErrorParser);
+
+  const errorMap = [
+    [ONE_INCH_ERRORS.INTERNAL_ERROR, ThirdPartyError.prototype.name],
+    [ONE_INCH_ERRORS.INVALID_TOKEN_ADDRESS, InternalError.prototype.name],
+  ];
+
+  it('should not log anything to console', () => {
+    const logSpy = jest.spyOn(console, 'log');
+
+    getError(() => {
+      return parser.wrap(() => {
+        throw FAKE_ERROR;
+      }, null);
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it.each(errorMap)("should map '%s' => '%s'", (sourceError, liqError) => {
+    const validError: OneInchError = {
+      statusCode: 400,
+      error: 'Bad Request',
+      description: new RandExp(sourceError).gen(),
+      requestId: 'string',
+      meta: [
+        {
+          type: 'string',
+          value: 'string',
+        },
+      ],
+      name: 'NodeError',
+    };
+
+    const error: LiqualityError = getError(() => {
+      parser.wrap(() => {
+        throw validError;
+      }, null);
+    });
+
+    expect(error.name).toBe(liqError);
+    expect(error.source).toBe(OneInchApproveErrorParser.prototype.errorSource);
+    expect(error.devMsg.data).toBe(null);
+    expect(error.rawError).toBe(validError);
+  });
+
+  const wrongErrors = [
+    ['error structure is incorrect', FAKE_ERROR],
+    [
+      'name is not nodeError',
+      {
+        description: new RandExp(ONE_INCH_ERRORS.INSUFFICIENT_FUNDS).gen(),
+        name: 'NodeErrr',
+      },
+    ],
+    [
+      'description is incorrect',
+      {
+        description: FAKE_ERROR,
+        name: 'NodeError',
+      },
+    ],
+  ];
+  it.each(wrongErrors)('Should return unknown error when %s', (_test, error) => {
+    const liqError: LiqualityError = getError(() => {
+      parser.wrap(() => {
+        throw error;
+      }, null);
+    });
+    expect(liqError.name).toBe(UnknownError.prototype.name);
+  });
+});

--- a/packages/error-parser/src/types/types.ts
+++ b/packages/error-parser/src/types/types.ts
@@ -1,20 +1,6 @@
 // An Error source can refer to endpoint(s)(Rpc or Api), a package/package function(s), Contract/Contract function(s)
 // It's just a database of functionalities consumed by Liquality whether they are external or internal so long as they do not themselves use the liquality Error Parser package
 
-export enum ErrorType {
-  InsufficientLiquidityError = 'InsufficientLiquidityError',
-  InsufficientAllowanceError = 'InsufficientAllowanceError',
-  InsufficientFundsError = 'InsufficientFundsError',
-  InsufficientGasFeeError = 'InsufficientGasFeeError',
-  ThirdPartyError = 'ThirdPartyError',
-  InternalError = 'InternalError',
-  UnknownError = 'UnknownError',
-}
-
-export enum ErrorSource {
-  OneInchSwapAPI = 'OneInchSwapAPI',
-}
-
 export enum ReportType {
   Console = 'Console',
   Discord = 'Discord',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,6 +2699,7 @@ __metadata:
   resolution: "@liquality/error-parser@workspace:packages/error-parser"
   dependencies:
     "@types/randombytes": ^2.0.0
+    randexp: ^0.5.3
     randombytes: ^2.1.0
   languageName: unknown
   linkType: soft
@@ -6468,6 +6469,13 @@ __metadata:
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 38e902c80b0666ab59e9310a3d24ed237029a7ce34d976796349765ac96b8d769f6df19090f1f471b77a25ca391971efde8a1ea63bb83111bd8bec8e5cc9b2cd
+  languageName: node
+  linkType: hard
+
+"drange@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "drange@npm:1.1.1"
+  checksum: 7e6ed639f9ab4d826e79717e2b0685a7ab02ecd39dac6483305dcc43ea2a27dc78b538e10adaba35c086efab216ef1f53f22bc402abfd0d29454b1c5f48fecd1
   languageName: node
   linkType: hard
 
@@ -12201,6 +12209,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"randexp@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "randexp@npm:0.5.3"
+  dependencies:
+    drange: ^1.0.2
+    ret: ^0.2.0
+  checksum: 9a4011b4b012debea545fc379a18208876fffc1179d2ac211351caf7626a3956efc4bc41e329bc5b241a671553eda58e0703933a9bcfdf90dde501ba1a2cf40a
+  languageName: node
+  linkType: hard
+
 "randombytes@npm:^2.0.0, randombytes@npm:^2.0.1, randombytes@npm:^2.0.5, randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
@@ -12559,6 +12577,13 @@ __metadata:
   dependencies:
     lowercase-keys: ^2.0.0
   checksum: b122535466e9c97b55e69c7f18e2be0ce3823c5d47ee8de0d9c0b114aa55741c6db8bfbfce3766a94d1272e61bfb1ebf0a15e9310ac5629fbb7446a861b4fd3a
+  languageName: node
+  linkType: hard
+
+"ret@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "ret@npm:0.2.2"
+  checksum: 774964bb413a3525e687bca92d81c1cd75555ec33147c32ecca22f3d06409e35df87952cfe3d57afff7650a0f7e42139cf60cb44e94c29dde390243bc1941f16
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR does the following: 
1. cleanup codebase
2. update tests
3. add error parsers for other one inch APIs we consume.