### PR TITLE
fix: resolve issue with transaction status not updating for send and swap

### DIFF
--- a/.changeset/calm-eagles-suffer.md
+++ b/.changeset/calm-eagles-suffer.md
@@ -1,7 +1,0 @@
----
-'@liquality/cryptoassets': major
-'@liquality/error-parser': major
-'@liquality/wallet-core': major
----
-
-test: bump all along with error parser

--- a/.changeset/fair-bugs-rush.md
+++ b/.changeset/fair-bugs-rush.md
@@ -1,0 +1,7 @@
+---
+'@liquality/error-parser': patch
+'@liquality/wallet-core': patch
+---
+
+fix: issue with transaction status not updating properly
+fix: add source to error report object

--- a/.changeset/fuzzy-turtles-turn.md
+++ b/.changeset/fuzzy-turtles-turn.md
@@ -1,6 +1,0 @@
----
-'@liquality/error-parser': patch
----
-
-fix: add translation files for other languages
-fix: add reportable field to error so that not all errors get reported.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,12 +2,9 @@
   "mode": "pre",
   "tag": "next",
   "initialVersions": {
-    "@liquality/cryptoassets": "1.16.3-next.4",
-    "@liquality/error-parser": "1.1.4-next.4",
-    "@liquality/wallet-core": "1.31.4-next.4"
+    "@liquality/cryptoassets": "2.0.0-next.5",
+    "@liquality/error-parser": "2.0.0-next.5",
+    "@liquality/wallet-core": "2.0.0-next.5"
   },
-  "changesets": [
-    "calm-eagles-suffer",
-    "fuzzy-turtles-turn"
-  ]
+  "changesets": ["fair-bugs-rush"]
 }

--- a/packages/error-parser/src/reporters/console.ts
+++ b/packages/error-parser/src/reporters/console.ts
@@ -9,6 +9,7 @@ function prepareErrorForConsole(error: LiqualityError | LiqualityErrorJSON) {
   return `New Error From Error Parser \n
           ID: ${error.data.errorId} \n
           Name: ${error.name} \n
+          Source: ${error.source} \n
           Developer Message: ${JSON.stringify(error.devMsg)} \n
           Raw Error: ${JSON.stringify(error.rawError)} \n
           Data: ${JSON.stringify(error.data)} \n

--- a/packages/error-parser/src/reporters/discord.ts
+++ b/packages/error-parser/src/reporters/discord.ts
@@ -19,6 +19,7 @@ function prepareErrorForDiscord(error: LiqualityError | LiqualityErrorJSON) {
   return `**New Error From Error Parser** \n
           ID: ${error.data.errorId} \n
           Name: ${error.name} \n
+          Source: ${error.source} \n
           Developer Message: ${JSON.stringify(error.devMsg)} \n
           Raw Error: ${JSON.stringify(error.rawError)} \n
           Data: ${JSON.stringify(error.data)} \n

--- a/packages/wallet-core/README.md
+++ b/packages/wallet-core/README.md
@@ -32,7 +32,7 @@ Wallet Core is a cryptocurrency wallet library in Typescript. It provides an abs
 
 ```typescript
 import { setupWallet } from '@liquality/wallet-core';
-import defaultOptions from '@liquality/wallet-core/dist/src/walletOptions/defaultOptions' // Default options
+import defaultOptions from '@liquality/wallet-core/dist/src/walletOptions/defaultOptions'; // Default options
 
 const wallet = setupWallet({
   ...defaultOptions,

--- a/packages/wallet-core/src/utils/isTransactionNotFoundError.ts
+++ b/packages/wallet-core/src/utils/isTransactionNotFoundError.ts
@@ -1,6 +1,10 @@
 import { TxNotFoundError } from '@chainify/errors';
 import { LiqualityError } from '@liquality/error-parser';
 
-export function isTransactionNotFoundError(error: LiqualityError): boolean {
-  return ((error as LiqualityError).rawError as Error).name === TxNotFoundError.name;
+export function isTransactionNotFoundError(error: Error): boolean {
+  if (error instanceof LiqualityError) {
+    return ((error as LiqualityError).rawError as Error)?.name === TxNotFoundError.prototype.name;
+  } else {
+    return error.name === TxNotFoundError.prototype.name;
+  }
 }


### PR DESCRIPTION
fix: issue with transaction status not updating properly
fix: add a source field to the error report object, to identify the source of the error

Reference ticket here:
https://linear.app/liquality/issue/COR-76/high-all-eth-transactions-are-displayed-as-failed-in-wallet
https://linear.app/liquality/issue/LIQ-1709/swap-failed-for-optimism-chain-using-lifi-rates-on-stage1-and-on-retry
https://linear.app/liquality/issue/COR-77/common-error-message-displaying-in-the-wallet-regardless-of-the-issue