### PR TITLE
fix: fixes to error parser

### DIFF
--- a/.changeset/metal-moles-swim.md
+++ b/.changeset/metal-moles-swim.md
@@ -1,0 +1,7 @@
+---
+'@liquality/error-parser': patch
+'@liquality/wallet-core': patch
+---
+
+fix: add error parser for uniswapV2
+fix: split messages going to discord

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -14,6 +14,7 @@
     "lazy-melons-judge",
     "light-avocados-lie",
     "strange-timers-provide",
-    "violet-shrimps-notice"
+    "violet-shrimps-notice",
+    "metal-moles-swim"
   ]
 }

--- a/packages/error-parser/src/LiqualityErrors/ValidationError.ts
+++ b/packages/error-parser/src/LiqualityErrors/ValidationError.ts
@@ -1,0 +1,13 @@
+import { ERROR_NAMES } from '../config';
+import { LiqualityError } from './LiqualityError';
+export class ValidationError extends LiqualityError {
+  reportable = true;
+
+  constructor() {
+    super(ERROR_NAMES.ValidationError);
+  }
+
+  setTranslationKey() {
+    this.translationKey = '';
+  }
+}

--- a/packages/error-parser/src/LiqualityErrors/ValidationError.ts
+++ b/packages/error-parser/src/LiqualityErrors/ValidationError.ts
@@ -1,8 +1,6 @@
 import { ERROR_NAMES } from '../config';
 import { LiqualityError } from './LiqualityError';
 export class ValidationError extends LiqualityError {
-  reportable = true;
-
   constructor() {
     super(ERROR_NAMES.ValidationError);
   }

--- a/packages/error-parser/src/LiqualityErrors/index.ts
+++ b/packages/error-parser/src/LiqualityErrors/index.ts
@@ -13,6 +13,7 @@ export { PasswordError } from './PasswordError';
 export { SlippageTooHighError } from './SlippageTooHighError';
 export { ThirdPartyError } from './ThirdPartyError';
 export { UnknownError } from './UnknownError';
+export { ValidationError } from './ValidationError';
 export { NoTipError } from './NoTipError';
 export { WalletLockedError } from './WalletLockedError';
 export { VeryLowTipError } from './VeryLowTipError';

--- a/packages/error-parser/src/config.ts
+++ b/packages/error-parser/src/config.ts
@@ -15,6 +15,7 @@ export const ERROR_NAMES = {
   SlippageTooHighError: 'SlippageTooHighError',
   ThirdPartyError: 'ThirdPartyError',
   UnknownError: 'UnknownError',
+  ValidationError: 'ValidationError',
   NoTipError: 'NoTipError',
   WalletLockedError: 'WalletLockedError',
   VeryLowTipError: 'VeryLowTipError',

--- a/packages/error-parser/src/parsers/Chainify/ChainifyErrorParser.ts
+++ b/packages/error-parser/src/parsers/Chainify/ChainifyErrorParser.ts
@@ -7,6 +7,7 @@ import { InternalError, LowSpeedupFeeError, UnknownError } from '../../Liquality
 import { LedgerErrorParser } from './LedgerErrorParser';
 import { getErrorParser } from '../../factory';
 import { JsonRPCNodeErrorParser } from './JsonRPCNodeErrorParser';
+import { UniswapV2SwapErroParser } from '../UniswapV2/UniswapV2SwapErrorParser';
 export class ChainifyErrorParser extends ErrorParser<Error, null> {
   public static readonly errorSource = ChainifyErrorSource;
 
@@ -15,6 +16,7 @@ export class ChainifyErrorParser extends ErrorParser<Error, null> {
 
     switch (error.name) {
       case ChainifyErrors.NodeError.prototype.name:
+        if (error.message.includes('UniswapV2')) return getErrorParser(UniswapV2SwapErroParser).parseError(error, null);
         return getErrorParser(JsonRPCNodeErrorParser).parseError(error, null);
       case ChainifyErrors.InvalidAddressError.prototype.name:
       case ChainifyErrors.InvalidDestinationAddressError.prototype.name:

--- a/packages/error-parser/src/parsers/Chainify/index.ts
+++ b/packages/error-parser/src/parsers/Chainify/index.ts
@@ -17,4 +17,5 @@ export const LEDGER_ERRORS = {
 
 export const JSON_RPC_NODE_ERRORS = {
   INSUFFICIENT_GAS_PRICE_RSK: "transaction's gas price lower than block's minimum",
+  UNSUPPORTED_SWAP_METHOD_FOR_TOKEN_TYPE: '',
 };

--- a/packages/error-parser/src/parsers/Chainify/index.ts
+++ b/packages/error-parser/src/parsers/Chainify/index.ts
@@ -17,5 +17,4 @@ export const LEDGER_ERRORS = {
 
 export const JSON_RPC_NODE_ERRORS = {
   INSUFFICIENT_GAS_PRICE_RSK: "transaction's gas price lower than block's minimum",
-  UNSUPPORTED_SWAP_METHOD_FOR_TOKEN_TYPE: '',
 };

--- a/packages/error-parser/src/parsers/UniswapV2/UniswapV2SwapErrorParser.ts
+++ b/packages/error-parser/src/parsers/UniswapV2/UniswapV2SwapErrorParser.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { LiqualityError, UnknownError } from '../../LiqualityErrors';
+import { UNISWAP_V2_ERROR_SOURCE_NAME, UNISWAP_V2_ERRORS } from '.';
+import { ErrorParser } from '../ErrorParser';
+import { ValidationError } from '../../LiqualityErrors/ValidationError';
+export class UniswapV2SwapErroParser extends ErrorParser<Error, UniswapV2SwapErrorParserDataType> {
+  public static readonly errorSource = UNISWAP_V2_ERROR_SOURCE_NAME;
+
+  protected _parseError(error: Error, data?: UniswapV2SwapErrorParserDataType): LiqualityError {
+    let liqError: LiqualityError;
+    let desc = '';
+    switch (true) {
+      case error.message.includes(UNISWAP_V2_ERRORS.UNSUPPORTED_SWAP_METHOD_FOR_TOKEN_TYPE):
+        liqError = new ValidationError();
+        desc =
+          'This is happening because the token involved in the swap is an FOT(fee on transfer) token. the supportingFeeOnTransfer token group of methods should be used. (See https://github.com/Uniswap/interface/issues/835)';
+        break;
+      default:
+        liqError = new UnknownError();
+        break;
+    }
+
+    liqError.source = UniswapV2SwapErroParser.errorSource;
+    liqError.devMsg = {
+      desc,
+      data: data || {},
+    };
+    liqError.rawError = error;
+
+    return liqError;
+  }
+}
+
+export type UniswapV2SwapErrorParserDataType = null;

--- a/packages/error-parser/src/parsers/UniswapV2/index.ts
+++ b/packages/error-parser/src/parsers/UniswapV2/index.ts
@@ -1,0 +1,5 @@
+export const UNISWAP_V2_ERROR_SOURCE_NAME = 'UniswapV2';
+
+export const UNISWAP_V2_ERRORS = {
+  UNSUPPORTED_SWAP_METHOD_FOR_TOKEN_TYPE: 'UniswapV2: K',
+};

--- a/packages/error-parser/src/parsers/index.ts
+++ b/packages/error-parser/src/parsers/index.ts
@@ -5,4 +5,5 @@ export * from './LifiAPI/QuoteErrorParser';
 export * from './Chainify/ChainifyErrorParser';
 export * from './Debridge/DebridgeAPIErrorParser';
 export * from './Thorchain/ThorchainAPIErrorParser';
+export * from './UniswapV2/UniswapV2SwapErrorParser';
 export * from './ErrorParser';

--- a/packages/error-parser/src/reporters/discord.ts
+++ b/packages/error-parser/src/reporters/discord.ts
@@ -3,12 +3,16 @@ import { HttpClient } from '@chainify/client';
 import { LiqualityErrorJSON } from '../types';
 
 export const reportToDiscord = async (error: LiqualityError | LiqualityErrorJSON) => {
-  new HttpClient({})
-    .nodePost(`${process.env.VUE_APP_DISCORD_WEBHOOK}`, {
-      content: prepareErrorForDiscord(error),
-      username: 'Error Parser',
-    })
-    .catch(ignoreError);
+  const messages = prepareErrorForDiscord(error);
+  const htttpClient = new HttpClient({});
+  messages.forEach((message) => {
+    htttpClient
+      .nodePost(`${process.env.VUE_APP_DISCORD_WEBHOOK}`, {
+        content: message,
+        username: 'Error Parser',
+      })
+      .catch(ignoreError);
+  });
 };
 
 function ignoreError(e: any) {
@@ -16,12 +20,48 @@ function ignoreError(e: any) {
 }
 
 function prepareErrorForDiscord(error: LiqualityError | LiqualityErrorJSON) {
-  return `**New Error From Error Parser** \n
-          ID: ${error.data.errorId} \n
-          Name: ${error.name} \n
-          Source: ${error.source} \n
-          Developer Message: ${JSON.stringify(error.devMsg)} \n
-          Raw Error: ${JSON.stringify(error.rawError)} \n
-          Data: ${JSON.stringify(error.data)} \n
-          Stack: ${error.stack} \n`;
+  const header = `**New Error From Error Parser** \n
+  ID: ${error.data.errorId} \n
+  Name: ${error.name} \n
+  Source: ${error.source} \n
+  Developer Message: ${JSON.stringify(error.devMsg)} \n`;
+
+  const footer = `Data: ${JSON.stringify(error.data)} \n
+  Stack: ${error.stack} \n`;
+
+  const DISCORD_CHARACTER_LIMIT = 1900; // ought to be 2000 but using 1900 just to be safe.
+  const maxLengthForRawError = DISCORD_CHARACTER_LIMIT - (header.length + footer.length);
+  const rawErrorString = JSON.stringify(error.rawError);
+
+  let start = 0;
+  let end = maxLengthForRawError;
+  const splittedRawError = [];
+
+  if (rawErrorString.length > maxLengthForRawError) {
+    while (start !== end) {
+      splittedRawError.push(rawErrorString.substring(start, end));
+      start = end;
+      if (end + maxLengthForRawError > rawErrorString.length) end = rawErrorString.length;
+      else end += maxLengthForRawError;
+    }
+  }
+
+  if (splittedRawError.length === 0) {
+    return [
+      `${header}
+        Raw Error: ${JSON.stringify(error.rawError)} \n
+        ${footer}`,
+    ];
+  } else {
+    const messages: Array<string> = [];
+
+    splittedRawError.forEach((errorPart, index) => {
+      messages.push(`
+        ${header}
+        Raw Error (${index + 1} of ${splittedRawError.length}): ${JSON.stringify(errorPart)} \n
+        ${footer}`);
+    });
+
+    return messages;
+  }
 }

--- a/packages/error-parser/src/test/chainify/uniswapV2.test.ts
+++ b/packages/error-parser/src/test/chainify/uniswapV2.test.ts
@@ -1,0 +1,59 @@
+import { FAKE_ERROR, getError, getErrorAsync } from '..';
+import { LiqualityError } from '../../LiqualityErrors/LiqualityError';
+import { getErrorParser } from '../..';
+import { ChainifyErrorParser, UniswapV2SwapErroParser } from '../../parsers';
+import { ValidationError } from '../../LiqualityErrors/ValidationError';
+
+describe('UniswapV2Error parser', () => {
+  const parser = getErrorParser(ChainifyErrorParser);
+
+  const UNISWAP_V2_K_ERROR =
+    'cannot estimate gas; transaction may fail or may require manual gas limit [ See: https://links.ethers.org/v5-errors-UNPREDICTABLE_GAS_LIMIT ] (reason="execution reverted: UniswapV2: K", method="estimateGas", transaction={"from":"0x684C4274202a003fEbB2C12f6016aF090EbeC3aE","maxPriorityFeePerGas":{"type":"BigNumber","hex":"0x4c25524c"},"maxFeePerGas":{"type":"BigNumber","hex":"0x03a8c924a8"},"to":"0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D","value":{"type":"BigNumber","hex":"0x00"},"data":"0x18cbafe50000000000000000000000000000000000000000000000000097a5c8063cd000000000000000000000000000000000000000000000000000009429ae7945c24f00000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000684c4274202a003febb2c12f6016af090ebec3ae000000000000000000000000000000000000000000000000000000006384c60b0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000ae7ab96520de3a18e5e111b5eaab095312d7fe84000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","type":2,"accessList":null}, error={"reason":"processing response error","code":"SERVER_ERROR","body":"{"jsonrpc":"2.0","id":124,"error":{"code":3,"data":"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000c556e697377617056323a204b0000000000000000000000000000000000000000","message":"execution reverted: UniswapV2: K"}}","error":{"code":3,"data":"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000c556e697377617056323a204b0000000000000000000000000000000000000000"},"requestBody":"{"method":"eth_estimateGas","params":[{"type":"0x2","maxFeePerGas":"0x3a8c924a8","maxPriorityFeePerGas":"0x4c25524c","value":"0x0","from":"0x684c4274202a003febb2c12f6016af090ebec3ae","to":"0x7a250d5630b4cf539739df2c5dacb4c659f2488d","data":"0x18cbafe50000000000000000000000000000000000000000000000000097a5c8063cd000000000000000000000000000000000000000000000000000009429ae7945c24f00000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000684c4274202a003febb2c12f6016af090ebec3ae000000000000000000000000000000000000000000000000000000006384c60b0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000ae7ab96520de3a18e5e111b5eaab095312d7fe84000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"}],"id":124,"jsonrpc":"2.0"}","requestMethod":"POST","url":"https://mainnet.infura.io/v3/a2ad6f8c0e57453ca4918331f16de87d"}, code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.7.0)"';
+
+  const errorMap = [[UNISWAP_V2_K_ERROR, ValidationError.name]];
+
+  it('should not log anything to console', async () => {
+    const logSpy = jest.spyOn(console, 'log');
+
+    getError(() => {
+      return parser.wrap(() => {
+        throw FAKE_ERROR;
+      }, null);
+    });
+
+    await getErrorAsync(async () => {
+      return await parser.wrapAsync(async () => {
+        throw FAKE_ERROR;
+      }, null);
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it.each(errorMap)("should map '%s' => '%s'", async (sourceError, liqError) => {
+    const validError = {
+      message: sourceError,
+      name: 'NodeError',
+    };
+
+    const error: LiqualityError = getError(() => {
+      parser.wrap(() => {
+        throw validError;
+      }, null);
+    });
+
+    expect(error.name).toBe(liqError);
+    expect(error.source).toBe(UniswapV2SwapErroParser.errorSource);
+    expect(error.rawError).toBe(validError);
+
+    const error1: LiqualityError = await getErrorAsync(async () => {
+      await parser.wrapAsync(async () => {
+        throw validError;
+      }, null);
+    });
+
+    expect(error1.name).toBe(liqError);
+    expect(error1.source).toBe(UniswapV2SwapErroParser.errorSource);
+    expect(error1.rawError).toBe(validError);
+  });
+});


### PR DESCRIPTION
This PR does the following

1. Adds an error parser for UniswapV2 to detect when a supportingFeeOnTransferToken swap method should be used instead of a regular swap method
2. Update uniswapV2 swap provider in line with No.1 above
3. Splits long errors before reporting to discord in line with Discord's character limit


https://discord.com/channels/745324936607957022/745334389432647792/1046748601306587148