### PR TITLE
fix:  map 1006NotFound error to pair not supported

### DIFF
--- a/.changeset/dull-trainers-attack.md
+++ b/.changeset/dull-trainers-attack.md
@@ -1,0 +1,5 @@
+---
+'@liquality/error-parser': patch
+---
+
+fix: map 1006NotFound error to pair not supported- - 1inch probably didn't find token in their list enabled/supported ones

--- a/packages/error-parser/src/parsers/OneInchAPI/ApproveErrorParser.ts
+++ b/packages/error-parser/src/parsers/OneInchAPI/ApproveErrorParser.ts
@@ -3,7 +3,7 @@ import { LiqualityError, UserActivity } from '../../LiqualityErrors/LiqualityErr
 import { ErrorParser } from '../ErrorParser';
 import { oneInchInternalErrReason, OneInchError, ONE_INCH_ERRORS, oneInchApproveSourceName } from '.';
 import { InternalError, PairNotSupportedError, ThirdPartyError, UnknownError } from '../../LiqualityErrors';
-import { is1001ValidationError } from '../../utils';
+import { is1001ValidationError, is1006NotFoundError } from '../../utils';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export class OneInchApproveErrorParser extends ErrorParser<OneInchError, null> {
@@ -13,7 +13,7 @@ export class OneInchApproveErrorParser extends ErrorParser<OneInchError, null> {
     let liqError: LiqualityError;
     let devDesc = '';
 
-    if (is1001ValidationError(error)) {
+    if (is1001ValidationError(error) || is1006NotFoundError(error)) {
       liqError = new PairNotSupportedError();
     } else if (error?.name !== 'NodeError') {
       // All OneInch errors must satisfy this because they are already wrapped in chainify

--- a/packages/error-parser/src/parsers/OneInchAPI/SwapErrorParser.ts
+++ b/packages/error-parser/src/parsers/OneInchAPI/SwapErrorParser.ts
@@ -11,7 +11,7 @@ import {
   ThirdPartyError,
   UnknownError,
 } from '../../LiqualityErrors';
-import { is1001ValidationError } from '../../utils';
+import { is1001ValidationError, is1006NotFoundError } from '../../utils';
 
 export class OneInchSwapErrorParser extends ErrorParser<OneInchError, OneInchSwapParserDataType> {
   public static readonly errorSource = oneInchSwapSourceName;
@@ -20,7 +20,7 @@ export class OneInchSwapErrorParser extends ErrorParser<OneInchError, OneInchSwa
     let liqError: LiqualityError;
     let devDesc = '';
 
-    if (is1001ValidationError(error)) {
+    if (is1001ValidationError(error) || is1006NotFoundError(error)) {
       liqError = new PairNotSupportedError();
     } else if (error?.name !== 'NodeError') {
       // All OneInch errors must satisfy this because they are already wrapped in chainify

--- a/packages/error-parser/src/test/oneInch/approveAPI.test.ts
+++ b/packages/error-parser/src/test/oneInch/approveAPI.test.ts
@@ -2,7 +2,14 @@ import { OneInchError, ONE_INCH_ERRORS } from '../../parsers/OneInchAPI';
 import { FAKE_ERROR, getError } from '..';
 import { LiqualityError } from '../../LiqualityErrors/LiqualityError';
 import RandExp = require('randexp');
-import { getErrorParser, InternalError, OneInchApproveErrorParser, ThirdPartyError, UnknownError } from '../..';
+import {
+  getErrorParser,
+  InternalError,
+  OneInchApproveErrorParser,
+  PairNotSupportedError,
+  ThirdPartyError,
+  UnknownError,
+} from '../..';
 
 describe('OneInchApproveAPI parser', () => {
   const parser = getErrorParser(OneInchApproveErrorParser);
@@ -46,6 +53,29 @@ describe('OneInchApproveAPI parser', () => {
     });
 
     expect(error.name).toBe(liqError);
+    expect(error.source).toBe(OneInchApproveErrorParser.errorSource);
+    expect(error.devMsg.data).toEqual({});
+    expect(error.rawError).toBe(validError);
+  });
+
+  const recordLevelErrorMap = [
+    ['ValidationError', 1001],
+    ['NotFoundError', 1006],
+  ];
+
+  it.each(recordLevelErrorMap)("should map '%s' => '%s'", (errorName, errorCode) => {
+    const validError = {
+      code: +errorCode,
+      name: errorName,
+    };
+
+    const error: LiqualityError = getError(() => {
+      parser.wrap(() => {
+        throw validError;
+      }, null);
+    });
+
+    expect(error.name).toBe(PairNotSupportedError.name);
     expect(error.source).toBe(OneInchApproveErrorParser.errorSource);
     expect(error.devMsg.data).toEqual({});
     expect(error.rawError).toBe(validError);

--- a/packages/error-parser/src/test/oneInch/swapAPI.test.ts
+++ b/packages/error-parser/src/test/oneInch/swapAPI.test.ts
@@ -9,6 +9,7 @@ import {
   InsufficientLiquidityError,
   InternalError,
   OneInchSwapErrorParser,
+  PairNotSupportedError,
   ThirdPartyError,
   UnknownError,
 } from '../../';
@@ -90,6 +91,29 @@ describe('OneInchSwapAPI parser', () => {
     expect(error1.source).toBe(OneInchSwapErrorParser.errorSource);
     expect(error1.devMsg.data).toBe(data);
     expect(error1.rawError).toBe(validError);
+  });
+
+  const recordLevelErrorMap = [
+    ['ValidationError', 1001],
+    ['NotFoundError', 1006],
+  ];
+
+  it.each(recordLevelErrorMap)("should map '%s' => '%s'", (errorName, errorCode) => {
+    const validError = {
+      code: +errorCode,
+      name: errorName,
+    };
+
+    const error: LiqualityError = getError(() => {
+      parser.wrap(() => {
+        throw validError;
+      }, data);
+    });
+
+    expect(error.name).toBe(PairNotSupportedError.name);
+    expect(error.source).toBe(OneInchSwapErrorParser.errorSource);
+    expect(error.devMsg.data).toEqual(data);
+    expect(error.rawError).toBe(validError);
   });
 
   const wrongErrors = [

--- a/packages/error-parser/src/utils/index.ts
+++ b/packages/error-parser/src/utils/index.ts
@@ -35,3 +35,7 @@ export function errorName(error: any): string {
 export function is1001ValidationError(error: any) {
   return error.code === 1001 && error.name === 'ValidationError';
 }
+
+export function is1006NotFoundError(error: any) {
+  return error.code === 1006 && error.name === 'NotFoundError';
+}


### PR DESCRIPTION
- 1inch probably didn't find token in their list enabled/supported ones