### PR TITLE
fix: thorchain url fix

### DIFF
--- a/packages/wallet-core/src/build.config.ts
+++ b/packages/wallet-core/src/build.config.ts
@@ -216,7 +216,7 @@ const config: WalletCoreConfig = {
         name: 'Thorchain',
         icon: 'thorchain.svg',
         type: SwapProviderType.Thorchain,
-        thornode: 'https://thornode.thorchain.info',
+        thornode: 'https://thornode.ninerealms.com',
       },
       [SwapProviderType.Astroport]: {
         name: 'Astroport',


### PR DESCRIPTION
This PR Fixes the thorchain URL which was updated from `https://thornode.thorchain.info` to `https://thornode.ninerealms.com`